### PR TITLE
Fix Pytest package discovery

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,6 +21,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip' # Cache pip dependencies
 
+    - name: Set PYTHONPATH for package discovery
+      run: |
+        echo "PYTHONPATH=$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/src:$PYTHONPATH" >> $GITHUB_ENV
+
     - name: Install pip, pytest, and project dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/empathy_benchmark/__init__.py
+++ b/empathy_benchmark/__init__.py
@@ -1,0 +1,1 @@
+# Allows empathy_benchmark to be imported as a package


### PR DESCRIPTION
## Summary
- ensure empathy_benchmark can be imported as a package
- set PYTHONPATH so GitHub Actions can find package modules

## Testing
- `pytest -q tests/test_shadow_protocol.py` *(fails: command not found)*