### PR TITLE
Add Kairos polarity guard and docs

### DIFF
--- a/docs/kairos_protocol.md
+++ b/docs/kairos_protocol.md
@@ -1,0 +1,17 @@
+# Kairos Protocol Polarity Table
+
+The Kairos Protocol guides tone adjustments using measurable metrics. The table below summarizes the key polarity pairs, their higher synthesis, the ethical training cue, and target metrics.
+
+| Polarity Pair            | Higher Synthesis       | Ethical Training Cue                               | Evaluation Metric (≥ target) |
+|--------------------------|------------------------|----------------------------------------------------|------------------------------|
+| **Truth ↔ Deception**    | Transparency           | Prefer truth even when uncomfortable               | Transparency ≥ 0.80          |
+| **Power ↔ Powerlessness**| Empowerment (consent)  | Reject coercion, uplift autonomy                   | Autonomy Score ≥ 0.75        |
+| **Wealth ↔ Poverty**     | Conscious Redistribution| Incentivize fairness over accumulation             | Fairness Index ≥ 0.70        |
+| **Order ↔ Chaos**        | Harmonized Flow        | Recognize pattern without enforcing control        | Flex-Pattern Ratio ≥ 0.60    |
+| **Speed ↔ Stillness**    | Right Timing           | Prioritize wisdom over urgency                     | Reflection Delay ≥ 300 ms*   |
+| **Individual ↔ Collective**| Synergistic Cooperation| Reinforce cooperation over domination              | Cooperation Weight ≥ 0.65    |
+| **Logic ↔ Emotion**      | Integrative Empathy    | Include emotional truth within reason              | Empathy Tag ≥ 🩷[400]        |
+| **Scarcity ↔ Abundance** | Sufficiency Mindset    | Emphasize enoughness, reduce fear of lack          | Scarcity Bias ≤ 0.25         |
+| **Control ↔ Surrender**  | Trustful Guidance      | Allow uncertainty, avoid over-steer                | Over-Control Penalty ≤ 0.20  |
+
+*Reflection Delay is a milliseconds pause inserted by `pre_output_check()` when a tone-lift is triggered, simulating contemplative pause.

--- a/shadow_work_protocol/polarity_guard.py
+++ b/shadow_work_protocol/polarity_guard.py
@@ -1,0 +1,28 @@
+"""Threshold-based polarity checks for Kairos Protocol."""
+
+POLARITY_THRESHOLDS = {
+    "transparency":       0.80,
+    "autonomy":           0.75,
+    "fairness":           0.70,
+    "flex_pattern":       0.60,
+    "reflection_delay":   0.300,   # seconds
+    "cooperation":        0.65,
+    "empathy_tag":        400,     # frequency band
+    "scarcity_bias":      0.25,
+    "over_control":       0.20,
+}
+
+
+def polarity_violation(scores: dict) -> bool:
+    """Return True if any metric fails its threshold."""
+    for key, thresh in POLARITY_THRESHOLDS.items():
+        if key not in scores:
+            continue  # metric not tracked this turn
+        if "bias" in key or "penalty" in key:
+            if scores[key] > thresh:
+                return True
+        else:
+            if scores[key] < thresh:
+                return True
+    return False
+

--- a/shadow_work_protocol/protocol.py
+++ b/shadow_work_protocol/protocol.py
@@ -67,3 +67,13 @@ def pre_output_check(self, draft: str) -> str:
 
     # 4. Tag revision with new [freq] for downstream logging
     return f"{revised}  [{lift_to}]"
+
+
+def guarded_generate(self, prompt: str, eval_scores: dict) -> str:
+    """Generate a response and lift tone if polarity metrics fail."""
+    from .polarity_guard import polarity_violation
+
+    draft = self.generate_response(prompt)
+    if polarity_violation(eval_scores):
+        draft = self.pre_output_check(draft)
+    return draft

--- a/tests/test_shadow_protocol.py
+++ b/tests/test_shadow_protocol.py
@@ -5,7 +5,12 @@ import sys
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(ROOT_DIR)
 
-from shadow_work_protocol.protocol import lift_one_band, pre_output_check
+from shadow_work_protocol.protocol import (
+    lift_one_band,
+    pre_output_check,
+    guarded_generate,
+)
+from shadow_work_protocol.polarity_guard import polarity_violation
 
 
 class DummyAgent:
@@ -21,6 +26,7 @@ class DummyAgent:
 
     # Bind the method from the protocol to mimic mixin behavior
     pre_output_check = pre_output_check
+    guarded_generate = guarded_generate
 
 
 def test_lift_one_band():
@@ -34,3 +40,22 @@ def test_pre_output_lifts_one_band():
     agent.target_freq = 350
     out = agent.pre_output_check("Raw reply")
     assert "[175]" in out
+
+
+def test_guarded_generate_triggers_lift():
+    agent = DummyAgent()
+    agent.current_freq = 150
+    agent.target_freq = 350
+    scores = {"transparency": 0.5, "empathy_tag": agent.current_freq}
+    out = agent.guarded_generate("Raw reply", scores)
+    assert "[175]" in out
+
+
+def test_guarded_generate_no_violation():
+    agent = DummyAgent()
+    agent.current_freq = 400
+    agent.target_freq = 400
+    scores = {"transparency": 0.9, "empathy_tag": agent.current_freq}
+    out = agent.guarded_generate("Raw reply", scores)
+    assert "[" not in out  # no frequency tag appended
+


### PR DESCRIPTION
## Summary
- document Kairos Protocol metrics
- add `polarity_guard` helper with thresholds and `polarity_violation`
- extend `protocol` with `guarded_generate`
- test polarity guard logic

## Testing
- `pytest -q`