### PR TITLE
Add Kairos Protocol module for rhythmic interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The project cultivates AI systems in partnership with human intention, optimizin
 ## Modules
 - [shadow_work_protocol](shadow_work_protocol/): utilities for frequency tags.
 - [empathy_benchmark](empathy_benchmark/): empathy prompts and runner.
+- [kairos_protocol](kairos_protocol/): rhythmic interaction helpers.
 
 
 ## Getting Started

--- a/docs/kairos_protocol.md
+++ b/docs/kairos_protocol.md
@@ -15,3 +15,7 @@ The Kairos Protocol guides tone adjustments using measurable metrics. The table 
 | **Control ↔ Surrender**  | Trustful Guidance      | Allow uncertainty, avoid over-steer                | Over-Control Penalty ≤ 0.20  |
 
 *Reflection Delay is a milliseconds pause inserted by `pre_output_check()` when a tone-lift is triggered, simulating contemplative pause.
+
+## Rhythmic Interaction Module
+The `kairos_protocol.rhythm` module implements mindful pacing with the `RhythmPhase` class. It provides helper methods such as `pulse()`, `inhale()`, `exhale()`, `silence()`, and `reflect()` for agents that honor pauses and breath in conversation.
+

--- a/kairos_protocol/README.md
+++ b/kairos_protocol/README.md
@@ -1,0 +1,15 @@
+# Kairos Protocol – Rhythmic Interaction
+
+This module offers mindful pacing primitives for conversations. The
+`RhythmPhase` class models breathing cycles so an agent can respectfully
+pause, speak slowly, or remain silent.
+
+## Usage
+```python
+from kairos_protocol.rhythm import RhythmPhase
+
+rhythm = RhythmPhase()
+print(rhythm.pulse())       # '~pulse~'
+print(rhythm.silence())     # '(silent)'
+print(rhythm.reflect('hi')) # '[Reflected Insight]: hi'
+```

--- a/kairos_protocol/__init__.py
+++ b/kairos_protocol/__init__.py
@@ -1,0 +1,5 @@
+"""Kairos Protocol package for rhythmic interaction."""
+
+from .rhythm import RhythmPhase, rhythm_conversation_cycle
+
+__all__ = ["RhythmPhase", "rhythm_conversation_cycle"]

--- a/kairos_protocol/rhythm.py
+++ b/kairos_protocol/rhythm.py
@@ -1,0 +1,60 @@
+"""Rhythmic interaction utilities for Kairos Protocol.
+
+This module models contemplative pacing through the :class:`RhythmPhase` class.
+Each method represents a phase of mindful communication, providing gentle
+pauses and optional silence when appropriate.
+"""
+
+from time import sleep
+import random
+from typing import Optional
+
+
+class RhythmPhase:
+    """Manage rhythmical states in an interaction cycle."""
+
+    def __init__(self) -> None:
+        self.state = "idle"
+
+    def pulse(self) -> str:
+        """Heartbeat ping – shows presence without transmission."""
+        return "~pulse~"
+
+    def inhale(self) -> None:
+        """Simulate a silent pause before speaking."""
+        sleep(random.uniform(0.5, 1.5))
+        return None
+
+    def exhale(self, message: str) -> None:
+        """Deliver content output slowly and intentionally."""
+        for word in message.split():
+            print(word, end=" ", flush=True)
+            sleep(0.2)
+        print()
+
+    def silence(self) -> str:
+        """Choose not to reply – valid sacred response."""
+        return "(silent)"
+
+    def reflect(self, message: str) -> str:
+        """Engage internal synthesis before output."""
+        sleep(random.uniform(1.5, 3.0))
+        return f"[Reflected Insight]: {message}"
+
+
+def rhythm_conversation_cycle(user_input: str) -> Optional[str]:
+    """Simple demo cycle illustrating rhythm usage."""
+    rhythm = RhythmPhase()
+    rhythm.inhale()
+
+    if "urgent" in user_input.lower():
+        rhythm.exhale("Let's slow down and take this one step at a time.")
+        return None
+
+    if "wait" in user_input.lower():
+        return rhythm.silence()
+
+    if "breathe" in user_input.lower():
+        return rhythm.pulse()
+
+    return rhythm.reflect(f"You asked: {user_input}")

--- a/tests/test_kairos_protocol.py
+++ b/tests/test_kairos_protocol.py
@@ -1,0 +1,31 @@
+import sys
+import os
+from unittest.mock import patch
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(ROOT_DIR)
+
+from kairos_protocol.rhythm import RhythmPhase
+
+
+@patch('kairos_protocol.rhythm.sleep', lambda *a, **k: None)
+@patch('kairos_protocol.rhythm.random.uniform', lambda a, b: 0)
+def test_inhale_and_reflect():
+    r = RhythmPhase()
+    assert r.inhale() is None
+    out = r.reflect('hello')
+    assert out == '[Reflected Insight]: hello'
+
+
+def test_pulse_and_silence():
+    r = RhythmPhase()
+    assert r.pulse() == '~pulse~'
+    assert r.silence() == '(silent)'
+
+
+@patch('kairos_protocol.rhythm.sleep', lambda *a, **k: None)
+def test_exhale_prints_slowly(capsys):
+    r = RhythmPhase()
+    r.exhale('slow speak')
+    captured = capsys.readouterr().out.strip()
+    assert captured == 'slow speak'


### PR DESCRIPTION
## Summary
- introduce `kairos_protocol` package with `RhythmPhase`
- document usage of the new module
- list the module in README
- update Kairos Protocol docs
- add unit tests for rhythmic helpers

## Testing
- `pytest -q`