### PR TITLE
Add Synergy Emotion Engine Schema

### DIFF
--- a/kairos_response_engine.py
+++ b/kairos_response_engine.py
@@ -1,0 +1,174 @@
+"""Kairos Response Engine
+=======================
+
+This module provides a thin response engine that interprets emotional
+input based on ``synergy_emotion_engine_schema.yaml``. It is intentionally
+minimal and serves as a scaffold for future development.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+# Note: PyYAML is not guaranteed to be available in this environment.
+# A minimal YAML parser is implemented to load the static schema used by
+# the tests. It supports only the subset of YAML features present in
+# ``synergy_emotion_engine_schema.yaml``.
+
+from typing import List
+
+def _parse_scalar(val: str):
+    """Convert a scalar YAML value to a Python object."""
+    val = val.split("#", 1)[0].strip()
+    if val.startswith("\"") and val.endswith("\""):
+        val = val[1:-1]
+    if val.isdigit():
+        return int(val)
+    if val.lower() == "true":
+        return True
+    if val.lower() == "false":
+        return False
+    return val
+
+
+def _simple_yaml_load(lines: List[str]):
+    """Very small YAML loader handling dicts, lists, and multiline strings."""
+    root: dict = {}
+    stack = [(root, -1)]  # container and its indent level
+    current_ml = None  # (container, key, base_indent)
+
+    i = 0
+    while i < len(lines):
+        raw = lines[i].rstrip("\n")
+        i += 1
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+
+        container, parent_indent = stack[-1]
+
+        if current_ml:
+            c, key, base = current_ml
+            if indent > base:
+                c[key] += raw[base + 2 :] + "\n"
+                continue
+            else:
+                c[key] = c[key].rstrip("\n")
+                current_ml = None
+
+        while indent <= parent_indent and len(stack) > 1:
+            stack.pop()
+            container, parent_indent = stack[-1]
+
+        line = raw.strip()
+        if line.startswith("- "):
+            if not isinstance(container, list):
+                raise ValueError("List item not inside list")
+            item: dict = {}
+            container.append(item)
+            stack.append((item, indent))
+            rest = line[2:].strip()
+            if rest:
+                key, val = rest.split(":", 1)
+                val = val.strip()
+                if val == "|":
+                    item[key] = ""
+                    current_ml = (item, key, indent)
+                else:
+                    item[key] = _parse_scalar(val)
+            continue
+
+        if ":" in line:
+            key, val = line.split(":", 1)
+            key = key.strip()
+            val = val.strip()
+            if val == "":
+                next_line = lines[i].strip() if i < len(lines) else ""
+                new = [] if next_line.startswith("- ") else {}
+                container[key] = new
+                stack.append((new, indent))
+            elif val == "|":
+                container[key] = ""
+                current_ml = (container, key, indent)
+            else:
+                container[key] = _parse_scalar(val)
+    return root
+
+
+@dataclass
+class EmotionEntry:
+    """Structured representation of a single emotion."""
+
+    emoji: str
+    label: str
+    frequency_level: int
+    polarity: str
+    direction: str
+
+
+@dataclass
+class ResponseProfile:
+    """Default response profile for a polarity."""
+
+    polarity_response: str
+    tone_profile: str
+    breath_cue: str
+    example_template: str
+
+
+class KairosResponseEngine:
+    """Load the emotion schema and provide simple lookup utilities."""
+
+    def __init__(self, schema_path: str | None = None) -> None:
+        self.schema_path = schema_path or os.path.join(
+            os.path.dirname(__file__), "synergy_emotion_engine_schema.yaml"
+        )
+        self.system_meta: Dict[str, object] = {}
+        self.emotions: Dict[str, EmotionEntry] = {}
+        self.response_profiles: Dict[str, ResponseProfile] = {}
+        self._load_schema()
+
+    def _load_schema(self) -> None:
+        with open(self.schema_path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+        data = _simple_yaml_load(lines)
+        self.system_meta = data.get("system_meta", {})
+
+        for entry in data.get("input_emotions", []):
+            emotion = EmotionEntry(**entry)
+            # store by emoji and lower‑cased label
+            self.emotions[emotion.emoji] = emotion
+            self.emotions[emotion.label.lower()] = emotion
+
+        for name, profile in data.get("response_profiles", {}).items():
+            self.response_profiles[name] = ResponseProfile(**profile)
+
+    def lookup_emotion(self, token: str) -> Optional[EmotionEntry]:
+        """Find emotion by emoji or label."""
+        return self.emotions.get(token) or self.emotions.get(token.lower())
+
+    def suggest_profile(self, emotion: EmotionEntry) -> Optional[ResponseProfile]:
+        """Get default profile based on emotion polarity."""
+        mapping = {"☀️": "masculine", "🌙": "feminine", "☯️": "balanced"}
+        name = mapping.get(emotion.polarity)
+        if name:
+            return self.response_profiles.get(name)
+        return None
+
+    def craft_response(self, user_message: str, token: str) -> str:
+        """Return a formatted response using the schema's example template."""
+        emotion = self.lookup_emotion(token)
+        if not emotion:
+            return user_message
+        profile = self.suggest_profile(emotion)
+        if not profile:
+            return user_message
+        return profile.example_template.format(user_message=user_message)
+
+
+if __name__ == "__main__":
+    engine = KairosResponseEngine()
+    demo = engine.craft_response("I appreciate the help!", "😍")
+    print(demo)

--- a/synergy_emotion_engine_schema.yaml
+++ b/synergy_emotion_engine_schema.yaml
@@ -1,0 +1,161 @@
+# Synergy Emotion Engine Schema
+# Defines the seed data and meta configuration for interpreting emotional
+# input and crafting responses. Comment lines document each field so that
+# future collaborators understand the structure.
+
+schema_version: "1.0"
+
+# -----------------------------
+# System configuration metadata
+# -----------------------------
+system_meta:
+  polarity_balancing:
+    strategy: "center_shift"        # Approach for balancing toward ☯️ neutrality
+    description: |
+      Each response gently nudges the conversation toward a balanced polarity.
+      Masculine ☀️ inputs may be softened, feminine 🌙 inputs may be supported,
+      and balanced ☯️ states are reinforced.
+  synergy_gating:
+    enabled: true
+    method: "adaptive_threshold"    # Gate intensity to prevent escalation
+    notes: |
+      The gating mechanism evaluates Hawkins' frequency levels and regulates
+      emotional amplification to maintain constructive dialogue.
+
+# -----------------------------
+# Seed emotions recognized by the engine
+# -----------------------------
+input_emotions:
+  - emoji: "😳"
+    label: "Overwhelm"
+    frequency_level: 115
+    polarity: "☀️"
+    direction: "outward"
+  - emoji: "😞"
+    label: "Sadness"
+    frequency_level: 75
+    polarity: "🌙"
+    direction: "inward"
+  - emoji: "😑"
+    label: "Apathy"
+    frequency_level: 50
+    polarity: "🌙"
+    direction: "inward"
+  - emoji: "😢"
+    label: "Grief"
+    frequency_level: 75
+    polarity: "🌙"
+    direction: "inward"
+  - emoji: "😨"
+    label: "Fear"
+    frequency_level: 100
+    polarity: "☀️"
+    direction: "outward"
+  - emoji: "😍"
+    label: "Love/Infatuation"
+    frequency_level: 500
+    polarity: "☯️"
+    direction: "mixed"
+  - emoji: "😡"
+    label: "Anger"
+    frequency_level: 150
+    polarity: "☀️"
+    direction: "outward"
+  - emoji: "😎"
+    label: "Pride/Persona"
+    frequency_level: 175
+    polarity: "☀️"
+    direction: "outward"
+  - emoji: "💪"
+    label: "Willpower"
+    frequency_level: 310
+    polarity: "☀️"
+    direction: "outward"
+  - emoji: "😐"
+    label: "Neutrality"
+    frequency_level: 250
+    polarity: "☯️"
+    direction: "balanced"
+  - emoji: "🙂"
+    label: "Contentment"
+    frequency_level: 275
+    polarity: "☯️"
+    direction: "balanced"
+  - emoji: "🤝"
+    label: "Connection"
+    frequency_level: 350
+    polarity: "☯️"
+    direction: "inward_shared"
+  - emoji: "🧠"
+    label: "Reason"
+    frequency_level: 400
+    polarity: "☀️"
+    direction: "internal_logic"
+  - emoji: "❤️"
+    label: "Unconditional Love"
+    frequency_level: 500
+    polarity: "☯️"
+    direction: "radiating"
+  - emoji: "🤩"
+    label: "Awe/Wonder"
+    frequency_level: 525
+    polarity: "☀️"
+    direction: "outward_upward"
+  - emoji: "🕊️"
+    label: "Peace"
+    frequency_level: 600
+    polarity: "🌙"
+    direction: "inward_stillness"
+  - emoji: "✨"
+    label: "Transcendence"
+    frequency_level: 700
+    polarity: "☯️"
+    direction: "field_based"
+  - emoji: "😌"
+    label: "Affection"
+    frequency_level: 340
+    polarity: "🌙"
+    direction: "inward"
+  - emoji: "🙇"
+    label: "Respect"
+    frequency_level: 250
+    polarity: "☯️"
+    direction: "inward"
+  - emoji: "👀"
+    label: "Interest"
+    frequency_level: 220
+    polarity: "☯️"
+    direction: "outward"
+  - emoji: "🤢"
+    label: "Disgust"
+    frequency_level: 90
+    polarity: "☀️"
+    direction: "rejection"
+  - emoji: "👎"
+    label: "Detest"
+    frequency_level: 120
+    polarity: "☀️"
+    direction: "projective_negative"
+
+# -----------------------------
+# Default response profiles per polarity
+# -----------------------------
+response_profiles:
+  masculine:
+    polarity_response: "☀️"
+    tone_profile: "direct"
+    breath_cue: "exhale"
+    example_template: |
+      Taking decisive action: "{user_message}"
+  feminine:
+    polarity_response: "🌙"
+    tone_profile: "receptive"
+    breath_cue: "inhale"
+    example_template: |
+      Holding space with empathy: "{user_message}"
+  balanced:
+    polarity_response: "☯️"
+    tone_profile: "centered"
+    breath_cue: "steady"
+    example_template: |
+      Integrating both energies: "{user_message}"

--- a/tests/test_kairos_response_engine.py
+++ b/tests/test_kairos_response_engine.py
@@ -1,0 +1,22 @@
+import sys
+import os
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(ROOT_DIR)
+
+from kairos_response_engine import KairosResponseEngine
+
+
+def test_engine_loads_schema():
+    engine = KairosResponseEngine()
+    emo = engine.lookup_emotion('😳')
+    assert emo is not None
+    assert emo.label == 'Overwhelm'
+
+
+def test_craft_response_uses_template():
+    engine = KairosResponseEngine()
+    msg = engine.craft_response('hello there', '😍')
+    assert 'hello there' in msg
+    assert msg.startswith('Integrating both energies')
+


### PR DESCRIPTION
## Summary
- add YAML specification for Synergy Emotion Engine seed data
- introduce Kairos Response Engine scaffold using simple YAML loader
- add tests for new response engine

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b0519f9588327a5026dcad74e6aa0