### PR TITLE
Add FastAPI beta API scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ orchestrator.run_evolution_loop()
 ```
 The `EvolutionOrchestrator` can now execute its main loop (`run_evolution_loop`), using mock components for candidate proposal, evaluation, and storage. This provides a basic framework for the intended propose → score → evolve cycle.
 
+## API Quick Start
+The project includes a lightweight FastAPI service for programmatic access. Once
+deployed, you can generate completions with a simple `curl` request:
+
+```bash
+curl -H "x-api-key: YOUR_KEY" \
+     -d '{"prompt":"Write a kind greeting"}' \
+     -H "Content-Type: application/json" \
+     https://synergy-api-beta.fly.dev/generate
+```
+
+
 ## Roadmap
 - **v0.2 (Jun 2025):** MVP Hello-Evolve prototype, CI, docs complete.
 - **v0.3 (Jul 2025):** Streamlit dashboard, semantic diff viewer.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, HTTPException, Depends, Header
+from pydantic import BaseModel
+import random
+
+app = FastAPI(title="Synergy API (Private Beta)")
+
+API_KEYS = {"demo-key-123"}   # replace with Supabase lookup later
+
+
+def verify_key(x_api_key: str = Header(...)):
+    if x_api_key not in API_KEYS:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+class GenRequest(BaseModel):
+    prompt: str
+    max_tokens: int = 64
+
+
+class GenResponse(BaseModel):
+    completion: str
+    bsq_score: float
+
+
+@app.post("/generate", response_model=GenResponse, dependencies=[Depends(verify_key)])
+async def generate(req: GenRequest):
+    # TODO: call your model here; placeholder below
+    completion = f"(Echo) {req.prompt}"
+    bsq_score = round(random.uniform(0.4, 0.9), 3)  # placeholder
+    return {"completion": completion, "bsq_score": bsq_score}
+
+
+@app.get("/healthz")
+async def health():
+    return {"status": "ok"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.2


### PR DESCRIPTION
## Summary
- scaffold `api/main.py` with basic FastAPI service
- provide Dockerfile and requirements for running the API
- document API usage in the README

## Testing
- `pytest -q`
- `docker build -t synergy-api ./api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842081eb2a083278c268b0fa05e7d94