### PR TITLE
Add Fly deploy config and trim deps

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,12 @@
+app = "synergy-api-beta"
+primary_region = "ord"
+
+[build]
+  dockerfile = "api/Dockerfile"
+
+[http_service]
+  internal_port = 8000
+
+[vm]
+  size = "shared-cpu-1x"
+  memory = 256

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,10 @@
-# Core
 PyYAML
 openai
-
-# Database / Logging
 duckdb
-
-# Testing
-pytest
-flake8
-
-# Observability
 prometheus_client
-
-# Dashboard
-streamlit
-
-# LLM APIs
-huggingface_hub
-transformers
-torch
-
-# Environment Management
 python-dotenv
 requests
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.2
+huggingface_hub

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,0 +1,25 @@
+# Core
+PyYAML
+openai
+
+# Database / Logging
+duckdb
+
+# Testing
+pytest
+flake8
+
+# Observability
+prometheus_client
+
+# Dashboard
+streamlit
+
+# LLM APIs
+huggingface_hub
+transformers
+torch
+
+# Environment Management
+python-dotenv
+requests

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# smoke_test.sh - build and test the local API container
+set -euo pipefail
+
+IMAGE="synergy-api-local"
+CONTAINER="synergy-api-smoke"
+
+# Build the Docker image
+
+docker build -t "$IMAGE" -f api/Dockerfile .
+
+# Run the container in detached mode
+CID=$(docker run -d --rm --name "$CONTAINER" -p 8000:8000 "$IMAGE")
+
+# Wait for server to start
+sleep 5
+
+# Query the /generate endpoint
+curl -s -H "x-api-key: demo-key-123" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"ping"}' \
+     http://localhost:8000/generate
+
+docker stop "$CID" >/dev/null


### PR DESCRIPTION
## Summary
- add minimal `fly.toml` for deploying via Docker
- keep a `requirements_full.txt` and slim down `requirements.txt`
- local `smoke_test.sh` already provides quick container check
- confirm `/healthz` endpoint is present in `api/main.py`

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684326d57664832781769c27bd78b18a